### PR TITLE
make sacct-all.py compatible with python3

### DIFF
--- a/sacct-all.py
+++ b/sacct-all.py
@@ -20,14 +20,14 @@ raw = subprocess.check_output(["sacct", "--format=ALL", "-P",
 lines = raw.rstrip().splitlines()
 
 # Tabulate the field names (keys).
-keys = lines[0].strip().split(field_sep)
+keys = lines[0].decode('utf-8').strip().split(field_sep)
 field_count = len(keys)
 print("Found", len(lines), "lines")
 
 # Create a list of job steps.
 jobsteps = []
 for line in lines[1:]:
-    step = line.strip().split(field_sep)
+    step = line.decode('utf-8').strip().split(field_sep)
     assert(field_count == len(step))
     jobsteps.append(step)
 


### PR DESCRIPTION
When using `StdEnv/2020` I had sacct-all.py fail with this traceback:
```
$ sacct-all.py 164049
Traceback (most recent call last):
  File "/home/stuekero/.local/slurm_utils/sacct-all.py", line 23, in <module>
    keys = lines[0].strip().split(field_sep)
TypeError: a bytes-like object is required, not 'str'
```

This is due to the way Python 3 now handles strings (which are now Unicode) we need to decode the (raw) bytes output to (utf-8) strings.

This now works with both Python 2 and 3.